### PR TITLE
Add utility script to convert from Facebook's JSON message archive format

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ You will then be able to run scraper and parser via the `conversation-scraper` a
 
 See the following sections for a quick overview of the necessary steps, and check the help menu (-h or --help) for a detailed usage description.
 
+#### Using Facebook JSON Exported Data
+Run `python3 utils/convert.py --in MESSAGE_ARCHIVE_JSON --out CONVERTED_FILE` to convert from Facebook's JSON format to the format used by conversation-analyzer.
+
 ## Scraper
 In order to access Facebook conversations the following parameters are required: *cookie* and *fb_dtsg* and conversation ID.
 

--- a/utils/convert.py
+++ b/utils/convert.py
@@ -1,0 +1,45 @@
+import json
+import argparse
+import heapq
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+from src.model.message import Message
+from datetime import datetime
+from collections import namedtuple
+
+# For storing messages in an object that the heap can sort
+MessageTuple = namedtuple('MessageTuple', 'timestamp tiebreak_value message')
+
+parser = argparse.ArgumentParser(description='FB Message Archive Converter')
+parser.add_argument('--in', dest='archivePath', required=True, help="Path to JSON archive")
+parser.add_argument('--out', dest='outPath', required=True, help="Path to output file")
+args = parser.parse_args()
+
+with open(args.archivePath, 'r') as json_file:
+    data = json.load(json_file)
+
+heap = []
+message_senders = set()
+tiebreaker_counter = 0
+for message in data['messages']:
+    message_datetime = datetime.fromtimestamp(int(message['timestamp']))
+    if 'content' not in message:
+        # 'content' property contains the message text, other message types (stickers, media etc) use different
+        # properties which aren't handled here
+        continue
+    sender = message['sender_name'].encode('raw_unicode_escape').decode('utf-8')
+    message_content = message['content'].encode('raw_unicode_escape').decode('utf-8')
+    new_message = "{date} {time} {sender} {message}\n".format(date=message_datetime.strftime(Message.DATE_FORMAT),
+                                                              time=message_datetime.strftime(Message.TIME_FORMAT),
+                                                              sender=sender.replace(' ', ''),
+                                                              message=message_content.replace('\n', ' '))
+    heapq.heappush(heap, MessageTuple(timestamp=int(message['timestamp']), tiebreak_value=tiebreaker_counter,
+                                      message=new_message))
+    tiebreaker_counter += 1
+
+sorted_messages = sorted(heap, key=lambda x: x[0])
+# The messages were MessageTuples, now pull just the message string out
+sorted_messages = [item.message for item in sorted_messages]
+with open(args.outPath, 'w', encoding='utf-8') as out_file:
+    out_file.writelines(sorted_messages)


### PR DESCRIPTION
This script converts between Facebook's JSON message archive format and the text format used in this repo. I put the script in a new `utils/` folder, but if you'd prefer it somewhere else let me know.

I also added simple instructions to the README, but it would probably be best to re-write it to explain the Facebook export workflow as well.